### PR TITLE
Fix UserAuthForms component test

### DIFF
--- a/src/UserAuthForms.test.js
+++ b/src/UserAuthForms.test.js
@@ -4,7 +4,7 @@ import UserAuthForms from './UserAuthForms';
 describe('UserAuthForms', () => {
   test('renders UserAuthForms component', () => {
     render(<UserAuthForms />);
-    expect(screen.getByText(/sign up/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign Up/i })).toBeInTheDocument();
   });
 
   test('allows the user to enter their first name', () => {


### PR DESCRIPTION
This PR addresses the failing test case in `UserAuthForms.test.js` after the introduction of the Sign In form. The test was unable to find the 'Sign Up' text due to the dynamic switch between 'Sign Up' and 'Sign In' forms within the component. The test has been updated to check for the presence of the 'Sign Up' button, which is a more reliable element for the initial render state of the component.