### PR TITLE
Enhance SignInForm Unit Tests

### DIFF
--- a/src/SignInForm.test.js
+++ b/src/SignInForm.test.js
@@ -68,4 +68,55 @@ describe('SignInForm', () => {
 
     consoleSpy.mockRestore();
   });
+
+  describe('SignInForm - Additional Tests', () => {
+  
+  test('displays error messages when submitting the form with empty fields', () => {
+    render(<SignInForm />);
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(screen.queryByText(/please enter a valid email address/i)).toBeInTheDocument();
+    expect(screen.queryByText(/your password must have at least 8 characters/i)).toBeInTheDocument();
+  });
+
+  test('toggles error messages visibility with field content changes', () => {
+    render(<SignInForm />);
+    // Trigger error state
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'invalid' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'short' } });
+    // Clear error state
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    // Re-trigger error state
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'stillinvalid' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'tiny' } });
+    
+    expect(screen.queryByText(/please enter a valid email address/i)).toBeInTheDocument();
+    expect(screen.queryByText(/your password must have at least 8 characters/i)).toBeInTheDocument();
+  });
+
+  test.each([
+    ['user@', 'user@ is not a valid email'],
+    ['@example.com', '@example.com is missing local part'],
+    ['userexample.com', 'userexample.com is missing @ symbol'],
+    ['user@example', 'user@example is missing domain extension']
+  ])('validates the email format: %s', (email, _) => {
+    render(<SignInForm />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: email } });
+    expect(screen.queryByText(/please enter a valid email address/i)).toBeInTheDocument();
+  });
+
+  test('form submission with empty password field', () => {
+    render(<SignInForm />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(screen.queryByText(/your password must have at least 8 characters/i)).toBeInTheDocument();
+  });
+
+  test('accepts a password that is exactly 8 characters long', () => {
+    render(<SignInForm />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: '12345678' } });
+    expect(screen.queryByText(/your password must have at least 8 characters/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled();
+  });
 });


### PR DESCRIPTION
Added additional unit tests to enhance the test coverage for the SignInForm component. This includes testing form submission with empty fields, toggling of error messages with field content changes, validation of various invalid email formats, form submission with an empty password field, and accepting a password that is exactly 8 characters long.