### PR TITLE
Fix React DOM act Warning

### DIFF
--- a/src/test/SignInForm.test.js
+++ b/src/test/SignInForm.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SignInForm from '../SignInForm';
 


### PR DESCRIPTION
This pull request addresses the warning received regarding the deprecation of `ReactDOMTestUtils.act` in favor of `React.act`. The necessary adjustments were made in the `SignInForm.test.js` by importing `act` from `react` instead of `react-dom/test-utils`.