### PR TITLE
Update password validation to 10 characters minimum

### DIFF
--- a/src/SignInForm.js
+++ b/src/SignInForm.js
@@ -16,7 +16,7 @@ const SignInForm = () => {
     if (name === 'email') {
       validateEmail(value);
     } else if (name === 'password') {
-      setIsSignInPasswordValid(value.length >= 8);
+      setIsSignInPasswordValid(value.length >= 10);
     }
   };
 

--- a/src/SignUpForm.js
+++ b/src/SignUpForm.js
@@ -34,7 +34,7 @@ const SignUpForm = () => {
       hasUppercase: /[A-Z]/.test(password),
       hasLowercase: /[a-z]/.test(password),
       hasNumber: /[0-9]/.test(password),
-      isLongEnough: password.length >= 8,
+      isLongEnough: password.length >= 10,
     });
   };
 

--- a/src/test/SignInForm.test.js
+++ b/src/test/SignInForm.test.js
@@ -34,9 +34,9 @@ describe('SignInForm', () => {
   test('validates password length correctly', () => {
     render(<SignInForm />);
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'short' } });
-    expect(screen.queryByText(/your password must have at least 8 characters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/your password must have at least 10 characters/i)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'longenough' } });
-    expect(screen.queryByText(/your password must have at least 8 characters/i)).toBeNull();
+    expect(screen.queryByText(/your password must have at least 10 characters/i)).toBeNull();
   });
 
   test('disables sign-in button with invalid form', () => {


### PR DESCRIPTION
Updated password validation rules in SignInForm.js and SignUpForm.js to require a minimum password length of 10 characters. Corresponding unit tests in SignInForm.test.js have been updated to reflect this change.