### PR TITLE
Update password validation rules to accept passwords with 10 symbols length minimum

### DIFF
--- a/src/SignUpForm.js
+++ b/src/SignUpForm.js
@@ -34,7 +34,7 @@ const SignUpForm = () => {
       hasUppercase: /[A-Z]/.test(password),
       hasLowercase: /[a-z]/.test(password),
       hasNumber: /[0-9]/.test(password),
-      isLongEnough: password.length >= 8,
+      isLongEnough: password.length >= 10,
     });
   };
 

--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -61,12 +61,12 @@ describe('SignUpForm', () => {
     test('validates password criteria correctly', () => {
       const password = screen.getByLabelText(LABELS.password);
       fireEvent.change(password, { target: { value: 'short' } });
-      expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/red/);
-      fireEvent.change(password, { target: { value: 'LongEnough1' } });
+      expect(screen.getByText(/Minimum 10 characters/i).className).toMatch(/red/);
+      fireEvent.change(password, { target: { value: 'LongEnough123' } });
       expect(screen.getByText(/1 uppercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 lowercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 number/i).className).toMatch(/green/);
-      expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/green/);
+      expect(screen.getByText(/Minimum 10 characters/i).className).toMatch(/green/);
     });
   });
 


### PR DESCRIPTION
Updated the password validation rules in `SignUpForm.js` to require a minimum length of 10 characters. Adjusted related unit tests in `SignUpForm.test.js` to reflect this change.