### PR TITLE
Add unit tests for SignInForm and improve coverage for SignUpForm

### DIFF
--- a/src/SignInForm.test.js
+++ b/src/SignInForm.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SignInForm from './SignInForm';
+
+describe('SignInForm', () => {
+  beforeEach(() => {
+    render(<SignInForm />);
+  });
+
+  test('renders the sign-in form with all fields', () => {
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign In/i })).toBeInTheDocument();
+  });
+
+  describe('Field Entry', () => {
+    test('allows entry of email', () => {
+      const emailInput = screen.getByLabelText(/Email/i);
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      expect(emailInput).toHaveValue('test@example.com');
+    });
+
+    test('allows entry of password', () => {
+      const passwordInput = screen.getByLabelText(/Password/i);
+      fireEvent.change(passwordInput, { target: { value: 'Password123' } });
+      expect(passwordInput).toHaveValue('Password123');
+    });
+  });
+
+  describe('Form Validation', () => {
+    test('validates email format correctly', () => {
+      const emailInput = screen.getByLabelText(/Email/i);
+      fireEvent.change(emailInput, { target: { value: 'invalid' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeInTheDocument();
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeNull();
+    });
+
+    test('validates password length correctly', () => {
+      const passwordInput = screen.getByLabelText(/Password/i);
+      fireEvent.change(passwordInput, { target: { value: 'short' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeInTheDocument();
+      fireEvent.change(passwordInput, { target: { value: 'LongEnough1' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeNull();
+    });
+  });
+
+  describe('Form Submission', () => {
+    let consoleSpy;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    test('enables Sign In button with valid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'test@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'Password123' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).not.toBeDisabled();
+    });
+
+    test('disables Sign In button with invalid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'invalid' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'short' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).toBeDisabled();
+    });
+
+    test('calls console log with correct data on valid form submission', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'test@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'Password123' } });
+      fireEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      expect(consoleSpy).toHaveBeenLastCalledWith('Sign In submitted:', {
+        email: 'test@example.com',
+        password: 'Password123',
+      });
+    });
+  });
+});

--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -68,6 +68,24 @@ describe('SignUpForm', () => {
       expect(screen.getByText(/1 number/i).className).toMatch(/green/);
       expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/green/);
     });
+
+    test('shows error message for empty required fields', () => {
+      fireEvent.change(screen.getByLabelText(LABELS.firstName), { target: { value: '' } });
+      fireEvent.blur(screen.getByLabelText(LABELS.firstName));
+      expect(screen.queryByText(/First Name is required/i)).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText(LABELS.lastName), { target: { value: '' } });
+      fireEvent.blur(screen.getByLabelText(LABELS.lastName));
+      expect(screen.queryByText(/Last Name is required/i)).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText(LABELS.email), { target: { value: '' } });
+      fireEvent.blur(screen.getByLabelText(LABELS.email));
+      expect(screen.queryByText(/Email is required/i)).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText(LABELS.password), { target: { value: '' } });
+      fireEvent.blur(screen.getByLabelText(LABELS.password));
+      expect(screen.queryByText(/Password is required/i)).toBeInTheDocument();
+    });
   });
 
   describe('Form Submission', () => {
@@ -95,6 +113,12 @@ describe('SignUpForm', () => {
       const formData = fillOutForm();
       fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
       expect(consoleSpy).toHaveBeenLastCalledWith('Form submitted:', formData);
+    });
+
+    test('does not call console log on invalid form submission', () => {
+      fillOutForm({ email: 'invalid' });
+      fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
+      expect(consoleSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Added comprehensive unit tests for the SignInForm component, covering various scenarios such as field entry, form validation, and form submission. Improved the unit tests coverage for the SignUpForm component by adding tests for empty required fields and invalid form submission. Closes #232