### PR TITLE
Update password validation rules to 10 characters minimum

### DIFF
--- a/src/SignUpForm.js
+++ b/src/SignUpForm.js
@@ -134,7 +134,7 @@ const SignUpForm = () => {
               1 number
             </li>
             <li className={passwordValidations.isLongEnough ? 'green' : 'red'}>
-              Minimum 8 characters
+              Minimum 10 characters
             </li>
           </ul>
         </div>

--- a/src/SignUpForm.js
+++ b/src/SignUpForm.js
@@ -34,7 +34,7 @@ const SignUpForm = () => {
       hasUppercase: /[A-Z]/.test(password),
       hasLowercase: /[a-z]/.test(password),
       hasNumber: /[0-9]/.test(password),
-      isLongEnough: password.length >= 8,
+      isLongEnough: password.length >= 10,
     });
   };
 

--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -62,7 +62,7 @@ describe('SignUpForm', () => {
       const password = screen.getByLabelText(LABELS.password);
       fireEvent.change(password, { target: { value: 'short' } });
       expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/red/);
-      fireEvent.change(password, { target: { value: 'LongEnough1' } });
+      fireEvent.change(password, { target: { value: 'LongEnough123' } });
       expect(screen.getByText(/1 uppercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 lowercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 number/i).className).toMatch(/green/);

--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -66,7 +66,7 @@ describe('SignUpForm', () => {
       expect(screen.getByText(/1 uppercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 lowercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 number/i).className).toMatch(/green/);
-      expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/green/);
+      expect(screen.getByText(/Minimum 10 characters/i).className).toMatch(/green/);
     });
   });
 

--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -61,7 +61,7 @@ describe('SignUpForm', () => {
     test('validates password criteria correctly', () => {
       const password = screen.getByLabelText(LABELS.password);
       fireEvent.change(password, { target: { value: 'short' } });
-      expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/red/);
+      expect(screen.getByText(/Minimum 10 characters/i).className).toMatch(/red/);
       fireEvent.change(password, { target: { value: 'LongEnough123' } });
       expect(screen.getByText(/1 uppercase character/i).className).toMatch(/green/);
       expect(screen.getByText(/1 lowercase character/i).className).toMatch(/green/);


### PR DESCRIPTION
Updated the password validation rules in SignUpForm.js to require a minimum of 10 characters. Also updated the related unit tests in SignUpForm.test.js to reflect this change. The form text has been updated accordingly.

closes #3