### PR TITLE
Add unit tests for SignInForm

### DIFF
--- a/src/SignInForm.test.js
+++ b/src/SignInForm.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SignInForm from './SignInForm';
+
+describe('SignInForm', () => {
+  beforeEach(() => {
+    render(<SignInForm />);
+  });
+
+  test('renders the sign-in form with all fields', () => {
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign In/i })).toBeInTheDocument();
+  });
+
+  describe('Field Entry', () => {
+    test('allows entry of email', () => {
+      const emailInput = screen.getByLabelText(/Email/i);
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      expect(emailInput).toHaveValue('test@example.com');
+    });
+
+    test('allows entry of password', () => {
+      const passwordInput = screen.getByLabelText(/Password/i);
+      fireEvent.change(passwordInput, { target: { value: 'Password123' } });
+      expect(passwordInput).toHaveValue('Password123');
+    });
+  });
+
+  describe('Form Validation', () => {
+    test('validates email format correctly', () => {
+      const emailInput = screen.getByLabelText(/Email/i);
+      fireEvent.change(emailInput, { target: { value: 'invalid' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeInTheDocument();
+      fireEvent.change(emailInput, { target: { value: 'valid@example.com' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeNull();
+    });
+
+    test('validates password length correctly', () => {
+      const passwordInput = screen.getByLabelText(/Password/i);
+      fireEvent.change(passwordInput, { target: { value: 'short' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeInTheDocument();
+      fireEvent.change(passwordInput, { target: { value: 'LongEnough1' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeNull();
+    });
+  });
+
+  describe('Form Submission', () => {
+    let consoleSpy;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    test('enables Sign In button with valid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'valid@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'ValidPassword123' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).not.toBeDisabled();
+    });
+
+    test('disables Sign In button with invalid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'invalid' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'short' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).toBeDisabled();
+    });
+
+    test('calls console log with correct data on valid form submission', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'valid@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'ValidPassword123' } });
+      fireEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      expect(consoleSpy).toHaveBeenLastCalledWith('Sign In submitted:', {
+        email: 'valid@example.com',
+        password: 'ValidPassword123',
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Added comprehensive unit tests for the `SignInForm` component to ensure complete test coverage, including all edge cases. The tests cover rendering, field entry, form validation, and form submission.

### Changes
- Created `src/SignInForm.test.js` with the following tests:
  - Rendering of the sign-in form with all fields
  - Field entry for email and password
  - Form validation for email format and password length
  - Form submission with valid and invalid data

### Checklist
- [ ] Descriptive Title
- [ ] Detailed Description
- [ ] Small, Focused Changes
- [ ] Follow Project Conventions
- [ ] Include Tests
- [ ] Document New Code
- [ ] Self-Review Before Submitting
- [ ] Link to Supporting Information
- [ ] Provide Screenshots or Videos for UI Changes (if applicable)
- [ ] Engage in Constructive Feedback

For more details on best practices for creating pull requests, refer to [Best practices of Pull Requests creation](https://kb.epam.com/display/ETSTCC/Best+practices+of+Pull+Requests+creation).

Branch: `add-signin-form-unit-tests_v24`