### PR TITLE
Add unit tests for SignInForm

### DIFF
--- a/src/SignInForm.test.js
+++ b/src/SignInForm.test.js
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SignInForm from './SignInForm';
+
+describe('SignInForm', () => {
+  beforeEach(() => {
+    render(<SignInForm />);
+  });
+
+  test('renders the sign-in form with all fields', () => {
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign In/i })).toBeInTheDocument();
+  });
+
+  describe('Field Entry', () => {
+    test('allows entry of email', () => {
+      const email = 'test@example.com';
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: email } });
+      expect(screen.getByLabelText(/Email/i)).toHaveValue(email);
+    });
+
+    test('allows entry of password', () => {
+      const password = 'Password123';
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: password } });
+      expect(screen.getByLabelText(/Password/i)).toHaveValue(password);
+    });
+  });
+
+  describe('Form Validation', () => {
+    test('validates email format correctly', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'invalid' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeInTheDocument();
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'valid@example.com' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeNull();
+    });
+
+    test('validates password length correctly', () => {
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'short' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeInTheDocument();
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'LongEnough1' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeNull();
+    });
+  });
+
+  describe('Form Submission', () => {
+    let consoleSpy;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    test('enables Sign In button with valid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'valid@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'Password123' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).not.toBeDisabled();
+    });
+
+    test('disables Sign In button with invalid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'invalid' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'short' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).toBeDisabled();
+    });
+
+    test('calls console log with correct data on valid form submission', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'valid@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'Password123' } });
+      fireEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      expect(consoleSpy).toHaveBeenLastCalledWith('Sign In submitted:', { email: 'valid@example.com', password: 'Password123' });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the `SignInForm` component using the React Testing Library. The tests cover rendering, field entry, form validation, and form submission functionalities.

Key changes include:

### Unit Tests for `SignInForm`:

* **Rendering Tests**:
  - Ensures the sign-in form renders with all necessary fields (`Email`, `Password`, and `Sign In` button).

* **Field Entry Tests**:
  - Verifies that the user can enter values into the email and password fields.

* **Form Validation Tests**:
  - Validates the email format and password length, showing appropriate error messages for invalid inputs.

* **Form Submission Tests**:
  - Checks that the `Sign In` button is enabled only when the form is valid.
  - Ensures the `Sign In` button is disabled when the form is invalid.
  - Mocks the console log to verify that the correct data is logged upon valid form submission.
