### PR TITLE
Add unit tests for SignUpForm

### DIFF
--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -68,6 +68,16 @@ describe('SignUpForm', () => {
       expect(screen.getByText(/1 number/i).className).toMatch(/green/);
       expect(screen.getByText(/Minimum 8 characters/i).className).toMatch(/green/);
     });
+
+    test('validates password criteria with different cases', () => {
+      const password = screen.getByLabelText(LABELS.password);
+      fireEvent.change(password, { target: { value: 'NoNumber' } });
+      expect(screen.getByText(/1 number/i).className).toMatch(/red/);
+      fireEvent.change(password, { target: { value: 'nouppercase1' } });
+      expect(screen.getByText(/1 uppercase character/i).className).toMatch(/red/);
+      fireEvent.change(password, { target: { value: 'NOLOWERCASE1' } });
+      expect(screen.getByText(/1 lowercase character/i).className).toMatch(/red/);
+    });
   });
 
   describe('Form Submission', () => {
@@ -95,6 +105,12 @@ describe('SignUpForm', () => {
       const formData = fillOutForm();
       fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
       expect(consoleSpy).toHaveBeenLastCalledWith('Form submitted:', formData);
+    });
+
+    test('does not call console log on invalid form submission', () => {
+      fillOutForm({ email: 'invalid' });
+      fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
+      expect(consoleSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Added comprehensive unit tests for the SignUpForm component to ensure proper validation and functionality. These tests cover field entry, form validation, and form submission scenarios. Closes EPMXYZ-2370.