### PR TITLE
Add unit tests for SignInForm

### DIFF
--- a/src/SignInForm.test.js
+++ b/src/SignInForm.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SignInForm from './SignInForm';
+
+describe('SignInForm', () => {
+  beforeEach(() => {
+    render(<SignInForm />);
+  });
+
+  test('renders the sign-in form with all fields', () => {
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign In/i })).toBeInTheDocument();
+  });
+
+  describe('Field Entry', () => {
+    test('allows entry of email', () => {
+      const emailInput = screen.getByLabelText(/Email/i);
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      expect(emailInput).toHaveValue('test@example.com');
+    });
+
+    test('allows entry of password', () => {
+      const passwordInput = screen.getByLabelText(/Password/i);
+      fireEvent.change(passwordInput, { target: { value: 'password123' } });
+      expect(passwordInput).toHaveValue('password123');
+    });
+  });
+
+  describe('Form Validation', () => {
+    test('validates email format correctly', () => {
+      const emailInput = screen.getByLabelText(/Email/i);
+      fireEvent.change(emailInput, { target: { value: 'invalid' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeInTheDocument();
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      expect(screen.queryByText(/Please enter a valid email address/i)).toBeNull();
+    });
+
+    test('validates password length correctly', () => {
+      const passwordInput = screen.getByLabelText(/Password/i);
+      fireEvent.change(passwordInput, { target: { value: 'short' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeInTheDocument();
+      fireEvent.change(passwordInput, { target: { value: 'longenough' } });
+      expect(screen.queryByText(/Your password must have at least 8 characters/i)).toBeNull();
+    });
+  });
+
+  describe('Form Submission', () => {
+    let consoleSpy;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    test('enables Sign In button with valid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'test@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'password123' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).not.toBeDisabled();
+    });
+
+    test('disables Sign In button with invalid form', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'invalid' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'short' } });
+      expect(screen.getByRole('button', { name: /Sign In/i })).toBeDisabled();
+    });
+
+    test('calls console log with correct data on valid form submission', () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'test@example.com' } });
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'password123' } });
+      fireEvent.click(screen.getByRole('button', { name: /Sign In/i }));
+      expect(consoleSpy).toHaveBeenLastCalledWith('Sign In submitted:', {
+        email: 'test@example.com',
+        password: 'password123',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Added comprehensive unit tests for the SignInForm component to ensure proper functionality and validation. The tests cover rendering of the form, field entry, form validation, and form submission scenarios. The tests are designed to provide complete coverage and include edge cases.

Branch: add-signin-form-tests_v26