### PR TITLE
Improve unit tests coverage for SignUpForm

### DIFF
--- a/src/SignUpForm.test.js
+++ b/src/SignUpForm.test.js
@@ -96,5 +96,40 @@ describe('SignUpForm', () => {
       fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
       expect(consoleSpy).toHaveBeenLastCalledWith('Form submitted:', formData);
     });
+
+    test('does not call console log on invalid form submission', () => {
+      fillOutForm({ email: 'invalid' }); // Explicitly set an invalid field
+      fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles empty form submission', () => {
+      fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
+      expect(screen.getByRole('button', { name: BUTTON_TEXT })).toBeDisabled();
+    });
+
+    test('handles form submission with only whitespace', () => {
+      fillOutForm({
+        firstName: ' ',
+        lastName: ' ',
+        email: ' ',
+        password: ' ',
+      });
+      fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
+      expect(screen.getByRole('button', { name: BUTTON_TEXT })).toBeDisabled();
+    });
+
+    test('handles form submission with special characters', () => {
+      fillOutForm({
+        firstName: '!@#$%^&*()',
+        lastName: '!@#$%^&*()',
+        email: 'invalid@invalid',
+        password: 'Invalid1',
+      });
+      fireEvent.click(screen.getByRole('button', { name: BUTTON_TEXT }));
+      expect(screen.getByRole('button', { name: BUTTON_TEXT })).toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
Enhanced unit tests for the SignUpForm component to ensure comprehensive coverage, including edge cases. The tests now cover rendering, field entry, form validation, form submission, and various edge cases.

closes #4